### PR TITLE
Fix warnings

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1120;
-				LastUpgradeCheck = 1120;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = Ambi;
 				TargetAttributes = {
 					FC3BD6C523BAB3C800D673F2 = {
@@ -809,6 +809,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"macOS/Preview Content\"";
@@ -832,6 +833,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"macOS/Preview Content\"";

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		FC3BD74223BAB55000D673F2 /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC3BD74123BAB55000D673F2 /* Espera */; };
 		FC68EBA223BAB6150034978B /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC68EBA123BAB6150034978B /* Espera */; };
 		FC68EBA423BAB6A80034978B /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC68EBA323BAB6A80034978B /* Espera */; };
-		FC68EBD323BABEDF0034978B /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC68EBD223BABEDF0034978B /* Espera */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +112,7 @@
 		FC3BD72623BAB47300D673F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FC3BD72923BAB47300D673F2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		FC3BD72B23BAB47300D673F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FCCA5758242D63CC002E9B88 /* .. */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ..; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,7 +120,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC68EBD323BABEDF0034978B /* Espera in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,6 +153,7 @@
 		FC3BD6A223BAB36600D673F2 = {
 			isa = PBXGroup;
 			children = (
+				FCCA5758242D63CC002E9B88 /* .. */,
 				FC3BD73723BAB4E200D673F2 /* Shared */,
 				FC3BD6C723BAB3C800D673F2 /* iOS */,
 				FC3BD6DF23BAB40800D673F2 /* tvOS */,
@@ -302,7 +302,6 @@
 			);
 			name = iOS;
 			packageProductDependencies = (
-				FC68EBD223BABEDF0034978B /* Espera */,
 			);
 			productName = iOS;
 			productReference = FC3BD6C623BAB3C800D673F2 /* iOS.app */;
@@ -442,7 +441,6 @@
 			);
 			mainGroup = FC3BD6A223BAB36600D673F2;
 			packageReferences = (
-				FC68EBCF23BABED20034978B /* XCRemoteSwiftPackageReference "Espera" */,
 			);
 			productRefGroup = FC3BD6AC23BAB36600D673F2 /* Products */;
 			projectDirPath = "";
@@ -1028,17 +1026,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		FC68EBCF23BABED20034978B /* XCRemoteSwiftPackageReference "Espera" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:JagCesar/Espera.git";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		FC3BD74123BAB55000D673F2 /* Espera */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1050,11 +1037,6 @@
 		};
 		FC68EBA323BAB6A80034978B /* Espera */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = Espera;
-		};
-		FC68EBD223BABEDF0034978B /* Espera */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FC68EBCF23BABED20034978B /* XCRemoteSwiftPackageReference "Espera" */;
 			productName = Espera;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/watchOS WatchKit App.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/watchOS WatchKit App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR gets rid of warnings and errors.

It also uses Espera as a local package in the example project, as suggested by @dreampiggy.

I considered cherry-picking his commit, but the commit was dirty and contained stuff related to the `StretchProgressView`.