### PR TITLE
Use max size available for LoadingFlowerView

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		FC3BD74223BAB55000D673F2 /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC3BD74123BAB55000D673F2 /* Espera */; };
 		FC68EBA223BAB6150034978B /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC68EBA123BAB6150034978B /* Espera */; };
 		FC68EBA423BAB6A80034978B /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FC68EBA323BAB6A80034978B /* Espera */; };
+		FCE8D045243007D900B90083 /* Espera in Frameworks */ = {isa = PBXBuildFile; productRef = FCE8D044243007D900B90083 /* Espera */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -120,6 +121,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCE8D045243007D900B90083 /* Espera in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,6 +304,7 @@
 			);
 			name = iOS;
 			packageProductDependencies = (
+				FCE8D044243007D900B90083 /* Espera */,
 			);
 			productName = iOS;
 			productReference = FC3BD6C623BAB3C800D673F2 /* iOS.app */;
@@ -1038,6 +1041,10 @@
 			productName = Espera;
 		};
 		FC68EBA323BAB6A80034978B /* Espera */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Espera;
+		};
+		FCE8D044243007D900B90083 /* Espera */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Espera;
 		};

--- a/Example/Shared/ContentView.swift
+++ b/Example/Shared/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
             RotatingCircleWithGap()
             LoadingFlowerView()
         }
+        .background(Color.black)
     }
 }
 

--- a/Example/Shared/ContentView.swift
+++ b/Example/Shared/ContentView.swift
@@ -14,6 +14,8 @@ struct ContentView: View {
         VStack {
             RotatingCircleWithGap()
             LoadingFlowerView()
+                // Use fixedSize() to get default size of component, override with .frame()
+                .fixedSize()
         }
         .background(Color.black)
     }

--- a/Sources/Espera/Espera.swift
+++ b/Sources/Espera/Espera.swift
@@ -36,8 +36,8 @@ public struct RotatingCircleWithGap: View {
 private struct LoadingCircle: View {
     let circleColor: Color
     let scale: CGFloat
-    private let circleWidth: CGFloat = 8
-
+    let circleWidth: CGFloat
+    
     var body: some View {
         Circle()
             .fill(circleColor)
@@ -47,6 +47,7 @@ private struct LoadingCircle: View {
 }
 
 public struct LoadingFlowerView: View {
+    
     private let animationDuration: Double = 0.6
     private var singleCircleAnimationDuration: Double {
         return animationDuration/3
@@ -55,32 +56,34 @@ public struct LoadingFlowerView: View {
         Animation.linear(duration: animationDuration)
             .repeatForever(autoreverses: true)
     }
-
+    
     @State private var color: Color = .init(white: 0.3)
     @State private var scale: CGFloat = 0.98
-
+    
     public init() { }
-
+    
     public var body: some View {
-        HStack(spacing: 1) {
-            VStack(spacing: 2) {
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation.delay(singleCircleAnimationDuration*5))
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation.delay(singleCircleAnimationDuration*4))
-            }
-            VStack(alignment: .center, spacing: 1) {
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation)
-                LoadingCircle(circleColor: .clear, scale: 1)
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation.delay(singleCircleAnimationDuration*3))
-            }
-            VStack(alignment: .center, spacing: 2) {
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation.delay(singleCircleAnimationDuration*1))
-                LoadingCircle(circleColor: color, scale: scale)
-                    .animation(foreverAnimation.delay(singleCircleAnimationDuration*2))
+        GeometryReader { [color, scale, singleCircleAnimationDuration, foreverAnimation] reader in
+            HStack(spacing: 1) {
+                VStack(spacing: 2) {
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*5))
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*4))
+                }
+                VStack(alignment: .center, spacing: 1) {
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation)
+                    LoadingCircle(circleColor: .clear, scale: 1, circleWidth: reader.size.width)
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*3))
+                }
+                VStack(alignment: .center, spacing: 2) {
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*1))
+                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
+                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*2))
+                }
             }
         }
         .onAppear {

--- a/Sources/Espera/Espera.swift
+++ b/Sources/Espera/Espera.swift
@@ -63,33 +63,48 @@ public struct LoadingFlowerView: View {
     public init() { }
 
     public var body: some View {
-        GeometryReader { [color, scale, singleCircleAnimationDuration, foreverAnimation] reader in
-            HStack(spacing: 1) {
-                VStack(spacing: 2) {
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*5))
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*4))
+        GeometryReader { [color, scale, singleCircleAnimationDuration, foreverAnimation] reader -> AnyView in
+
+            let minLength = min(reader.size.width, reader.size.height)
+            let thirdOfMinLength = minLength / 3
+
+            let proportionalSpacing: CGFloat = 1 / 26
+            let spacing = minLength * proportionalSpacing
+
+            // THIS IS FINE :D
+            // Fix later, ok?
+            let leafDiameter = thirdOfMinLength - (spacing - proportionalSpacing * thirdOfMinLength)
+
+            return AnyView(
+                HStack(spacing: spacing) {
+                    VStack(spacing: spacing) {
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation.delay(singleCircleAnimationDuration*5))
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation.delay(singleCircleAnimationDuration*4))
+                    }
+                    VStack(alignment: .center, spacing: spacing) {
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation)
+                        LoadingCircle(circleColor: .clear, scale: 1, circleWidth: leafDiameter)
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation.delay(singleCircleAnimationDuration*3))
+                    }
+                    VStack(alignment: .center, spacing: spacing) {
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation.delay(singleCircleAnimationDuration*1))
+                        LoadingCircle(circleColor: color, scale: scale, circleWidth: leafDiameter)
+                            .animation(foreverAnimation.delay(singleCircleAnimationDuration*2))
+                    }
                 }
-                VStack(alignment: .center, spacing: 1) {
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation)
-                    LoadingCircle(circleColor: .clear, scale: 1, circleWidth: reader.size.width)
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*3))
-                }
-                VStack(alignment: .center, spacing: 2) {
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*1))
-                    LoadingCircle(circleColor: color, scale: scale, circleWidth: reader.size.width)
-                        .animation(foreverAnimation.delay(singleCircleAnimationDuration*2))
-                }
-            }
+            )
         }
         .onAppear {
             self.color = .white
-            self.scale = 1.02
+            self.scale = 1
         }
+        .aspectRatio(contentMode: .fit)
+        .frame(idealWidth: 26)
     }
 }
 

--- a/Sources/Espera/Espera.swift
+++ b/Sources/Espera/Espera.swift
@@ -37,7 +37,7 @@ private struct LoadingCircle: View {
     let circleColor: Color
     let scale: CGFloat
     let circleWidth: CGFloat
-    
+
     var body: some View {
         Circle()
             .fill(circleColor)
@@ -47,7 +47,7 @@ private struct LoadingCircle: View {
 }
 
 public struct LoadingFlowerView: View {
-    
+
     private let animationDuration: Double = 0.6
     private var singleCircleAnimationDuration: Double {
         return animationDuration/3
@@ -56,12 +56,12 @@ public struct LoadingFlowerView: View {
         Animation.linear(duration: animationDuration)
             .repeatForever(autoreverses: true)
     }
-    
+
     @State private var color: Color = .init(white: 0.3)
     @State private var scale: CGFloat = 0.98
-    
+
     public init() { }
-    
+
     public var body: some View {
         GeometryReader { [color, scale, singleCircleAnimationDuration, foreverAnimation] reader in
             HStack(spacing: 1) {


### PR DESCRIPTION
Previously the `LoadingFlowerView` was fixed at 8pts in diameter, this fix will use the full available width for the spinner